### PR TITLE
Add week creation/navigation + read-only past weeks; make tests storage-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,39 @@ A simple, responsive web application to manage your Fantasy Premier League team.
 5. **Filter**: Use the position dropdown to filter by player position
 6. **Delete**: Click "Delete" to remove players from your team
 
+## Weekly Management
+
+Manage your team week-by-week with built-in navigation and read-only safeguards.
+
+- **Controls**: `Prev`, `Next`, and `Create New Week` in the header with a `Week N` label.
+- **Read-only Mode**: Past weeks are read-only. Editing controls are disabled and the "Read-only" badge appears.
+- **Editing**: Only the current week is editable. Add/Edit/Delete, Captain/VC, and team membership toggles are disabled in read-only weeks.
+- **Navigation**: `Prev` is disabled on week 1. `Next` is disabled on the last available week.
+- **Create New Week**: Clones players from the current week (including captain/vice) and snapshots the team into the new week. Previous weeks are marked read-only.
+  - Note: Captain and Vice-Captain selections are copied to the new week. Changing them in a later week does not alter previous weeks (historical integrity).
+
+Data is stored in `localStorage` under `fpl-team-data` using a weekly schema:
+
+```json
+{
+  "version": "2.0",
+  "currentWeek": 2,
+  "weeks": {
+    "1": {
+      "players": [],
+      "captain": null,
+      "viceCaptain": null,
+      "teamMembers": [],
+      "teamStats": { "totalValue": 0, "playerCount": 0, "createdDate": "..." },
+      "isReadOnly": true
+    },
+    "2": { "players": [...], "captain": "...", "viceCaptain": "...", "teamMembers": [...], "teamStats": { ... }, "isReadOnly": false }
+  }
+}
+```
+
+Related tests: `__tests__/weekNavigation.test.js`, `__tests__/readonlyMode.test.js`.
+
 ## Running Locally
 
 To run this project on your local machine:
@@ -101,13 +134,15 @@ Works on all modern browsers including:
 All data is stored locally in your browser using localStorage. No external database required.
 
 ## Future roadmap ideas
-- proper database to allow multidevice usage
+- proper database to allow at minimum local persistent storage
+- enable local server accessible from internet 
+- utilize online hosted database to allow multidevice usage
 - authentication to protect data to myself only
 - managing week history
 
-## Potential implementation of database and authentication
-- use firebase for database
-- use firebase authentication for authentication
+## Potential implementation of database and authentication (online)
+- use firebase or supabase for database
+- use firebase or supabase authentication for authentication
 - added two readme files on the topic and options
 
 ---

--- a/__tests__/readonlyMode.test.js
+++ b/__tests__/readonlyMode.test.js
@@ -1,0 +1,97 @@
+const { createDOM, userEvent } = require('../test-utils');
+
+describe('Read-only mode for previous weeks', () => {
+  let window, document, fplManager;
+
+  beforeEach(async () => {
+    ({ window, document, fplManager } = await createDOM());
+    window.localStorage.clear();
+  });
+
+  const seedTwoPlayers = async () => {
+    // Open add modal and add player 1
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Player One', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'midfield', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'T1', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '6.0', window);
+    userEvent.select(document.querySelector('[data-testid="player-status-select"]'), 'green', window);
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    // Add player 2
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Player Two', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'forward', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'T2', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '7.5', window);
+    userEvent.select(document.querySelector('[data-testid="player-status-select"]'), 'yellow', window);
+    userEvent.submit(document.querySelector('#player-form'), window);
+  };
+
+  test('previous week shows Read-only state and disables edit controls', async () => {
+    await seedTwoPlayers();
+
+    // Set captain in week 1
+    const makeCaptainBtnWeek1 = document.querySelector('[data-testid^="make-captain-"]');
+    if (makeCaptainBtnWeek1) userEvent.click(makeCaptainBtnWeek1, window);
+
+    // Create a new week (week 2)
+    const createBtn = document.getElementById('create-week-btn');
+    userEvent.click(createBtn, window);
+
+    // Navigate back to week 1
+    const prevBtn = document.getElementById('prev-week-btn');
+    userEvent.click(prevBtn, window);
+
+    // Read-only should be set on previous week
+    const root = window.fplManager._getRootData();
+    expect(root.weeks['1'] && root.weeks['1'].isReadOnly).toBe(true);
+
+    // Badge should reflect read-only (inline style not 'none')
+    const roBadge = document.getElementById('week-readonly-badge');
+    expect(roBadge).not.toBeNull();
+    expect(roBadge.style.display).not.toBe('none');
+
+    // Buttons disabled in table for edit, delete, add-to-team
+    const anyEdit = document.querySelector('[data-testid^="edit-player-"]');
+    const anyDelete = document.querySelector('[data-testid^="delete-player-"]');
+    const anyAddToTeam = document.querySelector('[data-testid^="add-to-team-"]');
+    if (anyEdit) expect(anyEdit.disabled).toBe(true);
+    if (anyDelete) expect(anyDelete.disabled).toBe(true);
+    if (anyAddToTeam) expect(anyAddToTeam.disabled).toBe(true);
+  });
+
+  test('mutating actions in read-only week do nothing (guarded and/or disabled)', async () => {
+    await seedTwoPlayers();
+
+    // Remember initial data
+    const initialPlayers = fplManager.players.map(p => ({ ...p }));
+
+    // Create week 2 and go back to week 1
+    userEvent.click(document.getElementById('create-week-btn'), window);
+    userEvent.click(document.getElementById('prev-week-btn'), window);
+
+    // Add button should be disabled; clicking should not change state
+    const addBtn = document.querySelector('[data-testid="add-player-button"]');
+    expect(addBtn.disabled).toBe(true);
+    userEvent.click(addBtn, window);
+
+    // Try to set captain (if button exists, it should be disabled)
+    const makeCaptainBtn = document.querySelector('[data-testid^="make-captain-"]');
+    if (makeCaptainBtn) {
+      expect(makeCaptainBtn.disabled).toBe(true);
+      userEvent.click(makeCaptainBtn, window);
+    }
+
+    // Try to delete (if button exists, it's disabled)
+    const deleteBtn = document.querySelector('[data-testid^="delete-player-"]');
+    if (deleteBtn) {
+      expect(deleteBtn.disabled).toBe(true);
+      userEvent.click(deleteBtn, window);
+    }
+
+    // State remains unchanged
+    expect(fplManager.players.map(p => ({ ...p }))).toEqual(initialPlayers);
+  });
+});

--- a/__tests__/readonlyMode.test.js
+++ b/__tests__/readonlyMode.test.js
@@ -45,8 +45,8 @@ describe('Read-only mode for previous weeks', () => {
     userEvent.click(prevBtn, window);
 
     // Read-only should be set on previous week
-    const root = window.fplManager._getRootData();
-    expect(root.weeks['1'] && root.weeks['1'].isReadOnly).toBe(true);
+    const isRO = window.fplManager.isWeekReadOnly(1);
+    expect(isRO).toBe(true);
 
     // Badge should reflect read-only (inline style not 'none')
     const roBadge = document.getElementById('week-readonly-badge');

--- a/__tests__/weekNavigation.test.js
+++ b/__tests__/weekNavigation.test.js
@@ -1,0 +1,580 @@
+const { createDOM, userEvent } = require('../test-utils');
+
+describe('Week Navigation Controls', () => {
+  let window, document, fplManager;
+
+  beforeEach(async () => {
+    ({ window, document, fplManager } = await createDOM());
+    // Ensure clean storage between tests
+    window.localStorage.clear();
+  });
+
+  test('Switching weeks updates read-only badge and control enablement', async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+    const roBadge = document.getElementById('week-readonly-badge');
+    const prevBtn = document.getElementById('prev-week-btn');
+    const nextBtn = document.getElementById('next-week-btn');
+    const createBtn = document.getElementById('create-week-btn');
+
+    // Start on Week 1: badge hidden, add enabled, prev disabled, next disabled (only one week)
+    expect(roBadge.style.display === 'none' || roBadge.style.display === '').toBe(true);
+    expect(addButton.disabled).toBe(false);
+    expect(prevBtn.disabled).toBe(true);
+    expect(nextBtn.disabled).toBe(true);
+
+    // Add a player to expose row controls
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'BadgeGuy', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'midfield', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'BG', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '6', window);
+    const have = document.querySelector('[data-testid="player-have-checkbox"]');
+    have.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const player = fplManager.players.find(p => p.name === 'BadgeGuy');
+    const capBtnW1 = document.querySelector(`[data-testid="make-captain-${player.id}"]`);
+    const vcBtnW1 = document.querySelector(`[data-testid="make-vice-captain-${player.id}"]`);
+    const editBtnW1 = document.querySelector(`[data-testid="edit-player-${player.id}"]`);
+    const delBtnW1 = document.querySelector(`[data-testid="delete-player-${player.id}"]`);
+
+    // In Week 1 (editable): row controls enabled
+    expect(capBtnW1.disabled).toBe(false);
+    expect(vcBtnW1.disabled).toBe(false);
+    expect(editBtnW1.disabled).toBe(false);
+    expect(delBtnW1.disabled).toBe(false);
+
+    // Create Week 2: now on Week 2 (editable): badge hidden, add enabled, prev enabled, next disabled
+    userEvent.click(createBtn, window);
+    expect(roBadge.style.display === 'none' || roBadge.style.display === '').toBe(true);
+    expect(addButton.disabled).toBe(false);
+    expect(prevBtn.disabled).toBe(false);
+    expect(nextBtn.disabled).toBe(true);
+
+    // Controls on Week 2 should be enabled
+    const capBtnW2 = document.querySelector(`[data-testid=\"make-captain-${player.id}\"]`);
+    const vcBtnW2 = document.querySelector(`[data-testid=\"make-vice-captain-${player.id}\"]`);
+    const editBtnW2 = document.querySelector(`[data-testid=\"edit-player-${player.id}\"]`);
+    const delBtnW2 = document.querySelector(`[data-testid=\"delete-player-${player.id}\"]`);
+    expect(capBtnW2.disabled).toBe(false);
+    expect(vcBtnW2.disabled).toBe(false);
+    expect(editBtnW2.disabled).toBe(false);
+    expect(delBtnW2.disabled).toBe(false);
+
+    // Go back to Week 1: badge visible, add disabled, row controls disabled
+    userEvent.click(prevBtn, window);
+    expect(roBadge.style.display).not.toBe('none');
+    expect(addButton.disabled).toBe(true);
+    const capBtnBack = document.querySelector(`[data-testid=\"make-captain-${player.id}\"]`);
+    const vcBtnBack = document.querySelector(`[data-testid=\"make-vice-captain-${player.id}\"]`);
+    const editBtnBack = document.querySelector(`[data-testid=\"edit-player-${player.id}\"]`);
+    const delBtnBack = document.querySelector(`[data-testid=\"delete-player-${player.id}\"]`);
+    expect(capBtnBack.disabled).toBe(true);
+    expect(vcBtnBack.disabled).toBe(true);
+    expect(editBtnBack.disabled).toBe(true);
+    expect(delBtnBack.disabled).toBe(true);
+
+    // Forward to Week 2 again: badge hidden and controls enabled again
+    userEvent.click(nextBtn, window);
+    expect(roBadge.style.display === 'none' || roBadge.style.display === '').toBe(true);
+    expect(addButton.disabled).toBe(false);
+    const capBtnFwd = document.querySelector(`[data-testid=\"make-captain-${player.id}\"]`);
+    const vcBtnFwd = document.querySelector(`[data-testid=\"make-vice-captain-${player.id}\"]`);
+    const editBtnFwd = document.querySelector(`[data-testid=\"edit-player-${player.id}\"]`);
+    const delBtnFwd = document.querySelector(`[data-testid=\"delete-player-${player.id}\"]`);
+    expect(capBtnFwd.disabled).toBe(false);
+    expect(vcBtnFwd.disabled).toBe(false);
+    expect(editBtnFwd.disabled).toBe(false);
+    expect(delBtnFwd.disabled).toBe(false);
+  });
+
+  test("Toggling have from true to false in week 2 doesn’t remove player from week 1 teamMembers", async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add player with have=true in week 1
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Removable', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'midfield', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'TEAMX', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '6', window);
+    const have = document.querySelector('[data-testid="player-have-checkbox"]');
+    have.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const player = fplManager.players.find(p => p.name === 'Removable');
+
+    // Create week 2
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // In week 2, remove from team via remove indicator
+    const removeSpan = document.querySelector(`[data-testid="remove-from-team-${player.id}"]`);
+    if (removeSpan) userEvent.click(removeSpan, window);
+
+    const root = window.fplManager._getRootData();
+    const w1 = root.weeks['1'];
+    const w2 = root.weeks['2'];
+
+    // Week 1 still has the player in teamMembers
+    expect(w1.teamMembers.map(m => m.playerId)).toContain(player.id);
+    // Week 2 no longer has the player in teamMembers
+    expect(w2.teamMembers.map(m => m.playerId)).not.toContain(player.id);
+  });
+
+  test('Changing have from false to true in week 2 adds to teamMembers without altering week 1', async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add player with have=false in week 1
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Adder', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'midfield', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'TEAM1', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '6', window);
+    // leave have unchecked
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const player = fplManager.players.find(p => p.name === 'Adder');
+
+    // Create week 2
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // In week 2, click Add-to-team control to set have=true
+    const addToTeamBtn = document.querySelector(`[data-testid="add-to-team-${player.id}"]`);
+    if (addToTeamBtn) userEvent.click(addToTeamBtn, window);
+
+    const root = window.fplManager._getRootData();
+    const w1 = root.weeks['1'];
+    const w2 = root.weeks['2'];
+
+    // Week 1 remains without the player in teamMembers
+    expect(w1.teamMembers.map(m => m.playerId)).not.toContain(player.id);
+    // Week 2 now includes the player in teamMembers
+    expect(w2.teamMembers.map(m => m.playerId)).toContain(player.id);
+  });
+
+  test("Editing position/team in week 2 doesn’t mutate week 1 snapshots", async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add player in week 1 with initial position/team
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'FieldEdit', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'defence', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'OLD', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '5', window);
+    const have = document.querySelector('[data-testid="player-have-checkbox"]');
+    have.checked = true; // owned for clearer team snapshot
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const player = fplManager.players.find(p => p.name === 'FieldEdit');
+
+    // Create week 2
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // Edit in week 2: change position and team
+    const editBtn = document.querySelector(`[data-testid="edit-player-${player.id}"]`);
+    if (editBtn) userEvent.click(editBtn, window);
+    const posSelect = document.querySelector('[data-testid="player-position-select"]');
+    userEvent.select(posSelect, 'midfield', window);
+    const teamInput = document.querySelector('[data-testid="player-team-input"]');
+    teamInput.value = '';
+    userEvent.type(teamInput, 'NEW', window);
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const root = window.fplManager._getRootData();
+    const w1 = root.weeks['1'];
+    const w2 = root.weeks['2'];
+    const w1Player = (w1.players || []).find(p => p.id === player.id);
+    const w2Player = (w2.players || []).find(p => p.id === player.id);
+
+    // Week 1 retains original fields
+    expect(w1Player.position).toBe('defence');
+    expect(w1Player.team).toBe('OLD');
+
+    // Week 2 reflects edits
+    expect(w2Player.position).toBe('midfield');
+    expect(w2Player.team).toBe('NEW');
+  });
+
+  test("Deleting a player in week 2 doesn’t remove them from week 1’s players or teamMembers", async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add a player with have=true so they appear in teamMembers
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Deletable', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'defence', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'ZZZ', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '5', window);
+    const have = document.querySelector('[data-testid="player-have-checkbox"]');
+    have.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const player = fplManager.players.find(p => p.name === 'Deletable');
+
+    // Create week 2, which freezes week 1
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // Delete the player in week 2
+    // jsdom doesn't implement confirm; mock it to return true
+    window.confirm = jest.fn(() => true);
+    const delBtn = document.querySelector(`[data-testid="delete-player-${player.id}"]`);
+    if (delBtn) userEvent.click(delBtn, window);
+
+    const root = window.fplManager._getRootData();
+    const w1 = root.weeks['1'];
+    const w2 = root.weeks['2'];
+
+    // Week 1 still has the player in players and teamMembers
+    expect((w1.players || []).some(p => p.id === player.id)).toBe(true);
+    expect(w1.teamMembers.map(m => m.playerId)).toContain(player.id);
+
+    // Week 2 no longer has the player
+    expect((w2.players || []).some(p => p.id === player.id)).toBe(false);
+    expect(w2.teamMembers.map(m => m.playerId)).not.toContain(player.id);
+  });
+
+  test("Editing a non-owned player in week 2 doesn’t affect week 1’s snapshot state", async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add a player with have=false so not in teamMembers
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'BenchGuy', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'forward', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'YYY', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '4.5', window);
+    // leave have unchecked
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const player = fplManager.players.find(p => p.name === 'BenchGuy');
+
+    // Snapshot to week 2
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // Edit in week 2: adjust price and notes
+    const editBtn = document.querySelector(`[data-testid="edit-player-${player.id}"]`);
+    if (editBtn) userEvent.click(editBtn, window);
+    const priceInput = document.querySelector('[data-testid="player-price-input"]');
+    priceInput.value = '';
+    userEvent.type(priceInput, '5.0', window);
+    const notesInput = document.querySelector('[data-testid="player-notes-textarea"]');
+    userEvent.type(notesInput, 'bench updated', window);
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const root = window.fplManager._getRootData();
+    const w1 = root.weeks['1'];
+    const w2 = root.weeks['2'];
+
+    const w1Player = (w1.players || []).find(p => p.id === player.id);
+    const w2Player = (w2.players || []).find(p => p.id === player.id);
+
+    // Week 1 player data unchanged and not in teamMembers
+    expect(w1Player.price).toBe(4.5);
+    expect(w1Player.notes || '').toBe('');
+    expect(w1.teamMembers.map(m => m.playerId)).not.toContain(player.id);
+
+    // Week 2 player updated and still not in teamMembers (have remained false)
+    expect(w2Player.price).toBe(5.0);
+    expect(w2Player.notes).toBe('bench updated');
+    expect(w2.teamMembers.map(m => m.playerId)).not.toContain(player.id);
+  });
+
+  test("Editing a player's notes or price in week 2 doesn't change week 1 snapshot", async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add a player with have=true, price=6, no notes
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Editable', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'midfield', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'EEE', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '6', window);
+    const have = document.querySelector('[data-testid="player-have-checkbox"]');
+    have.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const player = fplManager.players.find(p => p.name === 'Editable');
+
+    // Create week 2 (snapshot week 1)
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // Edit in week 2: change price to 7 and add notes
+    const editBtnW2 = document.querySelector(`[data-testid="edit-player-${player.id}"]`);
+    if (editBtnW2) userEvent.click(editBtnW2, window);
+    // Update fields in modal
+    const priceInput = document.querySelector('[data-testid="player-price-input"]');
+    priceInput.value = '';
+    userEvent.type(priceInput, '7', window);
+    const notesInput = document.querySelector('[data-testid="player-notes-textarea"]');
+    userEvent.type(notesInput, 'changed', window);
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const root = window.fplManager._getRootData();
+    const w1 = root.weeks['1'];
+    const w2 = root.weeks['2'];
+
+    const w1Player = (w1.players || []).find(p => p.id === player.id);
+    const w2Player = (w2.players || []).find(p => p.id === player.id);
+
+    // Week 1 retains original price and notes
+    expect(w1Player.price).toBe(6);
+    expect(w1Player.notes || '').toBe('');
+
+    // Week 2 has updated price and notes
+    expect(w2Player.price).toBe(7);
+    expect(w2Player.notes).toBe('changed');
+
+    // teamStats totalValue updated only for week 2 (week 1 unchanged)
+    expect(w1.teamStats.totalValue).toBe(6);
+    expect(w2.teamStats.totalValue).toBe(7);
+  });
+
+  test('Toggling team membership in week 2 does not affect week 1 (historical integrity)', async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add Player InTeam and mark as have
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'InTeam', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'midfield', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'EEE', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '6', window);
+    const have = document.querySelector('[data-testid="player-have-checkbox"]');
+    have.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const player = fplManager.players.find(p => p.name === 'InTeam');
+
+    // Create week 2 (week 1 snapshot has player in team)
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // In week 2, remove from team via remove indicator
+    const removeSpan = document.querySelector(`[data-testid="remove-from-team-${player.id}"]`);
+    if (removeSpan) {
+      userEvent.click(removeSpan, window);
+    }
+
+    const root = window.fplManager._getRootData();
+    const w1 = root.weeks['1'];
+    const w2 = root.weeks['2'];
+
+    // Week 1 teamMembers remains with the player
+    expect(w1.teamMembers.map(m => m.playerId)).toContain(player.id);
+    // Week 2 teamMembers no longer contains the player
+    expect(w2.teamMembers.map(m => m.playerId)).not.toContain(player.id);
+  });
+
+  test('Changing captain in week 2 does not change week 1 (historical integrity)', async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add two players and mark both as have
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Cap One', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'midfield', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'AAA', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '9', window);
+    const have1 = document.querySelector('[data-testid="player-have-checkbox"]');
+    have1.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Cap Two', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'forward', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'BBB', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '8', window);
+    const have2 = document.querySelector('[data-testid="player-have-checkbox"]');
+    have2.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const p1 = fplManager.players.find(p => p.name === 'Cap One');
+    const p2 = fplManager.players.find(p => p.name === 'Cap Two');
+
+    // Set captain to p1 in week 1
+    const capBtnW1 = document.querySelector(`[data-testid="make-captain-${p1.id}"]`);
+    if (capBtnW1) userEvent.click(capBtnW1, window);
+
+    // Create week 2 (copies captain)
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // In week 2, set captain to p2
+    const capBtnW2 = document.querySelector(`[data-testid="make-captain-${p2.id}"]`);
+    if (capBtnW2) userEvent.click(capBtnW2, window);
+
+    // Navigate back to week 1 and verify captain unchanged
+    userEvent.click(document.getElementById('prev-week-btn'), window);
+    const root = window.fplManager._getRootData();
+    expect(root.weeks['1'].captain).toBe(p1.id);
+    expect(root.weeks['2'].captain).toBe(p2.id);
+  });
+
+  test('Changing vice-captain in week 2 does not change week 1 (historical integrity)', async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add two players and mark both as have
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'VC One', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'defence', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'CCC', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '5', window);
+    const have1 = document.querySelector('[data-testid="player-have-checkbox"]');
+    have1.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'VC Two', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'goalkeeper', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'DDD', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '4.5', window);
+    const have2 = document.querySelector('[data-testid="player-have-checkbox"]');
+    have2.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    const p1 = fplManager.players.find(p => p.name === 'VC One');
+    const p2 = fplManager.players.find(p => p.name === 'VC Two');
+
+    // Set vice to p1 in week 1
+    const vcBtnW1 = document.querySelector(`[data-testid="make-vice-captain-${p1.id}"]`);
+    if (vcBtnW1) userEvent.click(vcBtnW1, window);
+
+    // Create week 2 (copies vice)
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    // In week 2, set vice to p2
+    const vcBtnW2 = document.querySelector(`[data-testid="make-vice-captain-${p2.id}"]`);
+    if (vcBtnW2) userEvent.click(vcBtnW2, window);
+
+    // Navigate back to week 1 and verify vice unchanged
+    userEvent.click(document.getElementById('prev-week-btn'), window);
+    const root = window.fplManager._getRootData();
+    expect(root.weeks['1'].viceCaptain).toBe(p1.id);
+    expect(root.weeks['2'].viceCaptain).toBe(p2.id);
+  });
+
+  test('should render initial week label as Week 1', async () => {
+    const weekLabel = document.getElementById('week-label');
+    expect(weekLabel).not.toBeNull();
+    expect(weekLabel.textContent).toMatch(/Week\s+1/);
+  });
+
+  test('Create New Week sets current to new week and enables Prev', async () => {
+    const createBtn = document.getElementById('create-week-btn');
+    const prevBtn = document.getElementById('prev-week-btn');
+    const nextBtn = document.getElementById('next-week-btn');
+    const weekLabel = document.getElementById('week-label');
+
+    userEvent.click(createBtn, window);
+
+    expect(weekLabel.textContent).toMatch(/Week\s+2/);
+    expect(prevBtn.disabled).toBe(false);
+    // At last week, next should be disabled
+    expect(nextBtn.disabled).toBe(true);
+
+    // Read-only badge should be hidden on current editable week
+    const roBadge = document.getElementById('week-readonly-badge');
+    expect(roBadge.style.display === 'none' || roBadge.style.display === '').toBe(true);
+  });
+
+  test('Prev/Next navigate between weeks properly', async () => {
+    const createBtn = document.getElementById('create-week-btn');
+    const prevBtn = document.getElementById('prev-week-btn');
+    const nextBtn = document.getElementById('next-week-btn');
+    const weekLabel = document.getElementById('week-label');
+
+    // Create up to week 3
+    userEvent.click(createBtn, window); // -> week 2
+    userEvent.click(createBtn, window); // -> week 3
+
+    expect(weekLabel.textContent).toMatch(/Week\s+3/);
+    expect(nextBtn.disabled).toBe(true);
+
+    // Go to week 2
+    userEvent.click(prevBtn, window);
+    expect(weekLabel.textContent).toMatch(/Week\s+2/);
+    expect(nextBtn.disabled).toBe(false);
+
+    // Back to week 1
+    userEvent.click(prevBtn, window);
+    expect(weekLabel.textContent).toMatch(/Week\s+1/);
+    expect(prevBtn.disabled).toBe(true);
+  });
+
+  test('Prev disabled on week 1 and Next disabled on last week', async () => {
+    const prevBtn = document.getElementById('prev-week-btn');
+    const nextBtn = document.getElementById('next-week-btn');
+    const createBtn = document.getElementById('create-week-btn');
+
+    // Initial: only week 1 exists
+    expect(prevBtn.disabled).toBe(true);
+    expect(nextBtn.disabled).toBe(true);
+
+    // Create week 2 -> now at week 2 (last week)
+    userEvent.click(createBtn, window);
+    expect(prevBtn.disabled).toBe(false);
+    expect(nextBtn.disabled).toBe(true);
+
+    // Navigate back to week 1 -> not last week anymore
+    userEvent.click(prevBtn, window);
+    expect(prevBtn.disabled).toBe(true);
+    expect(nextBtn.disabled).toBe(false);
+  });
+
+  test('Creating new week snapshots teamMembers and teamStats', async () => {
+    const addButton = document.querySelector('[data-testid="add-player-button"]');
+
+    // Add Player A (have = true, price 10.0)
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Player A', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'midfield', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'AAA', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '10', window);
+    userEvent.select(document.querySelector('[data-testid="player-status-select"]'), 'green', window);
+    // mark have
+    const haveCheckbox = document.querySelector('[data-testid="player-have-checkbox"]');
+    haveCheckbox.checked = true;
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    // Add Player B (have = false, price 5.0)
+    userEvent.click(addButton, window);
+    userEvent.type(document.querySelector('[data-testid="player-name-input"]'), 'Player B', window);
+    userEvent.select(document.querySelector('[data-testid="player-position-select"]'), 'forward', window);
+    userEvent.type(document.querySelector('[data-testid="player-team-input"]'), 'BBB', window);
+    userEvent.type(document.querySelector('[data-testid="player-price-input"]'), '5', window);
+    userEvent.select(document.querySelector('[data-testid="player-status-select"]'), 'yellow', window);
+    // leave have unchecked
+    userEvent.submit(document.querySelector('#player-form'), window);
+
+    // Set captain and vice-captain in week 1
+    const pA = fplManager.players.find(p => p.name === 'Player A');
+    const pB = fplManager.players.find(p => p.name === 'Player B');
+    const capBtn = document.querySelector(`[data-testid="make-captain-${pA.id}"]`);
+    const vcBtn = document.querySelector(`[data-testid=\"make-vice-captain-${pB.id}\"]`);
+    if (capBtn) userEvent.click(capBtn, window);
+    if (vcBtn) userEvent.click(vcBtn, window);
+
+    // Create new week
+    userEvent.click(document.getElementById('create-week-btn'), window);
+
+    const root = window.fplManager._getRootData();
+    const w1 = root.weeks['1'];
+    const w2 = root.weeks['2'];
+
+    // Week 1 should be read-only after creating week 2
+    expect(w1.isReadOnly).toBe(true);
+    expect(w2.isReadOnly).toBe(false);
+
+    // teamMembers only include have=true players
+    expect(Array.isArray(w1.teamMembers)).toBe(true);
+    expect(Array.isArray(w2.teamMembers)).toBe(true);
+    expect(w1.teamMembers.length).toBe(1);
+    expect(w2.teamMembers.length).toBe(1);
+    expect(w1.teamMembers[0].name).toBe('Player A');
+    expect(w2.teamMembers[0].name).toBe('Player A');
+
+    // teamStats reflects value and count
+    expect(w1.teamStats.playerCount).toBe(1);
+    expect(w2.teamStats.playerCount).toBe(1);
+    expect(w1.teamStats.totalValue).toBe(10);
+    expect(w2.teamStats.totalValue).toBe(10);
+
+    // captain and vice are copied to new week
+    expect(w1.captain).toBe(pA.id);
+    expect(w2.captain).toBe(pA.id);
+    expect(w1.viceCaptain).toBe(pB.id);
+    expect(w2.viceCaptain).toBe(pB.id);
+  });
+});

--- a/__tests__/weekNavigation.test.js
+++ b/__tests__/weekNavigation.test.js
@@ -110,9 +110,8 @@ describe('Week Navigation Controls', () => {
     const removeSpan = document.querySelector(`[data-testid="remove-from-team-${player.id}"]`);
     if (removeSpan) userEvent.click(removeSpan, window);
 
-    const root = window.fplManager._getRootData();
-    const w1 = root.weeks['1'];
-    const w2 = root.weeks['2'];
+    const w1 = window.fplManager.getWeekSnapshot(1);
+    const w2 = window.fplManager.getWeekSnapshot(2);
 
     // Week 1 still has the player in teamMembers
     expect(w1.teamMembers.map(m => m.playerId)).toContain(player.id);
@@ -141,9 +140,8 @@ describe('Week Navigation Controls', () => {
     const addToTeamBtn = document.querySelector(`[data-testid="add-to-team-${player.id}"]`);
     if (addToTeamBtn) userEvent.click(addToTeamBtn, window);
 
-    const root = window.fplManager._getRootData();
-    const w1 = root.weeks['1'];
-    const w2 = root.weeks['2'];
+    const w1 = window.fplManager.getWeekSnapshot(1);
+    const w2 = window.fplManager.getWeekSnapshot(2);
 
     // Week 1 remains without the player in teamMembers
     expect(w1.teamMembers.map(m => m.playerId)).not.toContain(player.id);
@@ -179,11 +177,10 @@ describe('Week Navigation Controls', () => {
     userEvent.type(teamInput, 'NEW', window);
     userEvent.submit(document.querySelector('#player-form'), window);
 
-    const root = window.fplManager._getRootData();
-    const w1 = root.weeks['1'];
-    const w2 = root.weeks['2'];
-    const w1Player = (w1.players || []).find(p => p.id === player.id);
-    const w2Player = (w2.players || []).find(p => p.id === player.id);
+    const w1 = window.fplManager.getWeekSnapshot(1);
+    const w2 = window.fplManager.getWeekSnapshot(2);
+    const w1Player = window.fplManager.getPlayerSnapshot(1, player.id);
+    const w2Player = window.fplManager.getPlayerSnapshot(2, player.id);
 
     // Week 1 retains original fields
     expect(w1Player.position).toBe('defence');
@@ -218,9 +215,8 @@ describe('Week Navigation Controls', () => {
     const delBtn = document.querySelector(`[data-testid="delete-player-${player.id}"]`);
     if (delBtn) userEvent.click(delBtn, window);
 
-    const root = window.fplManager._getRootData();
-    const w1 = root.weeks['1'];
-    const w2 = root.weeks['2'];
+    const w1 = window.fplManager.getWeekSnapshot(1);
+    const w2 = window.fplManager.getWeekSnapshot(2);
 
     // Week 1 still has the player in players and teamMembers
     expect((w1.players || []).some(p => p.id === player.id)).toBe(true);
@@ -258,12 +254,11 @@ describe('Week Navigation Controls', () => {
     userEvent.type(notesInput, 'bench updated', window);
     userEvent.submit(document.querySelector('#player-form'), window);
 
-    const root = window.fplManager._getRootData();
-    const w1 = root.weeks['1'];
-    const w2 = root.weeks['2'];
+    const w1 = window.fplManager.getWeekSnapshot(1);
+    const w2 = window.fplManager.getWeekSnapshot(2);
 
-    const w1Player = (w1.players || []).find(p => p.id === player.id);
-    const w2Player = (w2.players || []).find(p => p.id === player.id);
+    const w1Player = window.fplManager.getPlayerSnapshot(1, player.id);
+    const w2Player = window.fplManager.getPlayerSnapshot(2, player.id);
 
     // Week 1 player data unchanged and not in teamMembers
     expect(w1Player.price).toBe(4.5);
@@ -305,12 +300,11 @@ describe('Week Navigation Controls', () => {
     userEvent.type(notesInput, 'changed', window);
     userEvent.submit(document.querySelector('#player-form'), window);
 
-    const root = window.fplManager._getRootData();
-    const w1 = root.weeks['1'];
-    const w2 = root.weeks['2'];
+    const w1 = window.fplManager.getWeekSnapshot(1);
+    const w2 = window.fplManager.getWeekSnapshot(2);
 
-    const w1Player = (w1.players || []).find(p => p.id === player.id);
-    const w2Player = (w2.players || []).find(p => p.id === player.id);
+    const w1Player = window.fplManager.getPlayerSnapshot(1, player.id);
+    const w2Player = window.fplManager.getPlayerSnapshot(2, player.id);
 
     // Week 1 retains original price and notes
     expect(w1Player.price).toBe(6);
@@ -349,9 +343,8 @@ describe('Week Navigation Controls', () => {
       userEvent.click(removeSpan, window);
     }
 
-    const root = window.fplManager._getRootData();
-    const w1 = root.weeks['1'];
-    const w2 = root.weeks['2'];
+    const w1 = window.fplManager.getWeekSnapshot(1);
+    const w2 = window.fplManager.getWeekSnapshot(2);
 
     // Week 1 teamMembers remains with the player
     expect(w1.teamMembers.map(m => m.playerId)).toContain(player.id);
@@ -397,9 +390,8 @@ describe('Week Navigation Controls', () => {
 
     // Navigate back to week 1 and verify captain unchanged
     userEvent.click(document.getElementById('prev-week-btn'), window);
-    const root = window.fplManager._getRootData();
-    expect(root.weeks['1'].captain).toBe(p1.id);
-    expect(root.weeks['2'].captain).toBe(p2.id);
+    expect(window.fplManager.getWeekSnapshot(1).captain).toBe(p1.id);
+    expect(window.fplManager.getWeekSnapshot(2).captain).toBe(p2.id);
   });
 
   test('Changing vice-captain in week 2 does not change week 1 (historical integrity)', async () => {
@@ -440,9 +432,8 @@ describe('Week Navigation Controls', () => {
 
     // Navigate back to week 1 and verify vice unchanged
     userEvent.click(document.getElementById('prev-week-btn'), window);
-    const root = window.fplManager._getRootData();
-    expect(root.weeks['1'].viceCaptain).toBe(p1.id);
-    expect(root.weeks['2'].viceCaptain).toBe(p2.id);
+    expect(window.fplManager.getWeekSnapshot(1).viceCaptain).toBe(p1.id);
+    expect(window.fplManager.getWeekSnapshot(2).viceCaptain).toBe(p2.id);
   });
 
   test('should render initial week label as Week 1', async () => {
@@ -549,13 +540,12 @@ describe('Week Navigation Controls', () => {
     // Create new week
     userEvent.click(document.getElementById('create-week-btn'), window);
 
-    const root = window.fplManager._getRootData();
-    const w1 = root.weeks['1'];
-    const w2 = root.weeks['2'];
+    const w1 = window.fplManager.getWeekSnapshot(1);
+    const w2 = window.fplManager.getWeekSnapshot(2);
 
     // Week 1 should be read-only after creating week 2
-    expect(w1.isReadOnly).toBe(true);
-    expect(w2.isReadOnly).toBe(false);
+    expect(window.fplManager.isWeekReadOnly(1)).toBe(true);
+    expect(window.fplManager.isWeekReadOnly(2)).toBe(false);
 
     // teamMembers only include have=true players
     expect(Array.isArray(w1.teamMembers)).toBe(true);

--- a/index.html
+++ b/index.html
@@ -14,6 +14,15 @@
                 <span id="team-count">In Team: 0/15</span>
                 <span id="total-value">Total Value: £0.0m</span>
             </div>
+            <div class="week-controls" data-testid="week-controls">
+                <button id="prev-week-btn" class="btn btn-secondary" data-testid="prev-week-btn">◀ Prev</button>
+                <div class="week-indicator" data-testid="week-indicator">
+                    <span id="week-label">Week 1</span>
+                    <span id="week-readonly-badge" class="readonly-badge" style="display:none;">Read-only</span>
+                </div>
+                <button id="next-week-btn" class="btn btn-secondary" data-testid="next-week-btn">Next ▶</button>
+                <button id="create-week-btn" class="btn btn-primary" data-testid="create-week-btn" style="margin-left:auto;">+ Create New Week</button>
+            </div>
         </header>
 
         <div class="controls" data-testid="controls-container">

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,32 @@
+// Jest setup: stub browser dialogs for jsdom environment
+// jsdom does not implement alert/confirm. Our app calls these in read-only guards
+// and delete confirmations, which would otherwise log noisy "Not implemented" errors.
+// We stub them here for all tests to keep output clean and deterministic.
+
+beforeAll(() => {
+  const w = global.window || global;
+
+  // Ensure alert exists on window and global, then stub it
+  if (typeof w.alert === 'undefined') {
+    w.alert = () => {};
+  }
+  if (typeof global.alert === 'undefined') {
+    global.alert = w.alert;
+  }
+  jest.spyOn(w, 'alert').mockImplementation(() => {});
+  if (w !== global && typeof global.alert === 'function') {
+    jest.spyOn(global, 'alert').mockImplementation(() => {});
+  }
+
+  // Ensure confirm exists on window and global, then stub it (default OK)
+  if (typeof w.confirm === 'undefined') {
+    w.confirm = () => true;
+  }
+  if (typeof global.confirm === 'undefined') {
+    global.confirm = w.confirm;
+  }
+  jest.spyOn(w, 'confirm').mockImplementation(() => true);
+  if (w !== global && typeof global.confirm === 'function') {
+    jest.spyOn(global, 'confirm').mockImplementation(() => true);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "setupFilesAfterEnv": ["@testing-library/jest-dom"],
+    "setupFilesAfterEnv": [
+      "@testing-library/jest-dom",
+      "<rootDir>/jest.setup.js"
+    ],
     "transform": {
       "^.+\\.js$": "babel-jest"
     }

--- a/script.js
+++ b/script.js
@@ -5,8 +5,11 @@ class FPLTeamManager {
         this.currentEditingId = null;
         this.captain = null;
         this.viceCaptain = null;
+        this.currentWeek = 1; // phase 2: track current week in memory
         
         this.initializeElements();
+        // Phase 1: migrate storage (if needed) before loading
+        this.migrateStorageIfNeeded();
         this.loadFromStorage();
         this.bindEvents();
         this.updateDisplay();
@@ -20,6 +23,12 @@ class FPLTeamManager {
         this.emptyState = document.getElementById('empty-state');
         this.positionFilter = document.querySelector('[data-testid="position-filter-select"]');
         this.haveFilter = document.querySelector('[data-testid="have-filter-checkbox"]');
+        // Week controls
+        this.weekLabel = document.getElementById('week-label');
+        this.weekReadonlyBadge = document.getElementById('week-readonly-badge');
+        this.prevWeekBtn = document.getElementById('prev-week-btn');
+        this.nextWeekBtn = document.getElementById('next-week-btn');
+        this.createWeekBtn = document.getElementById('create-week-btn');
         
         // Summary elements
         this.teamCount = document.getElementById('team-count');
@@ -68,9 +77,18 @@ class FPLTeamManager {
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') this.closeModal();
         });
+
+        // Week controls
+        this.prevWeekBtn?.addEventListener('click', () => this.prevWeek());
+        this.nextWeekBtn?.addEventListener('click', () => this.nextWeek());
+        this.createWeekBtn?.addEventListener('click', () => this.createNewWeek());
     }
     
     openModal(playerId = null) {
+        if (this._isReadOnlyCurrentWeek()) {
+            alert('This week is read-only. Create a new week to make changes.');
+            return;
+        }
         this.currentEditingId = playerId;
         
         if (playerId) {
@@ -153,6 +171,10 @@ class FPLTeamManager {
     }
     
     addPlayer(playerData) {
+        if (this._isReadOnlyCurrentWeek()) {
+            alert('This week is read-only. Create a new week to add players.');
+            return;
+        }
         const player = {
             id: Date.now().toString(),
             ...playerData
@@ -164,6 +186,10 @@ class FPLTeamManager {
     }
     
     updatePlayer(playerId, playerData) {
+        if (this._isReadOnlyCurrentWeek()) {
+            alert('This week is read-only. Create a new week to edit players.');
+            return;
+        }
         const playerIndex = this.players.findIndex(p => p.id === playerId);
         if (playerIndex !== -1) {
             this.players[playerIndex] = { ...this.players[playerIndex], ...playerData };
@@ -173,6 +199,10 @@ class FPLTeamManager {
     }
     
     deletePlayer(playerId) {
+        if (this._isReadOnlyCurrentWeek()) {
+            alert('This week is read-only. Create a new week to delete players.');
+            return;
+        }
         if (confirm('Are you sure you want to delete this player?')) {
             // Remove from captain/vice captain if applicable
             if (this.captain === playerId) this.captain = null;
@@ -185,6 +215,10 @@ class FPLTeamManager {
     }
     
     setCaptain(playerId) {
+        if (this._isReadOnlyCurrentWeek()) {
+            alert('This week is read-only. Create a new week to change captain.');
+            return;
+        }
         // If already captain, remove captaincy
         if (this.captain === playerId) {
             this.captain = null;
@@ -201,6 +235,10 @@ class FPLTeamManager {
     }
     
     setViceCaptain(playerId) {
+        if (this._isReadOnlyCurrentWeek()) {
+            alert('This week is read-only. Create a new week to change vice captain.');
+            return;
+        }
         // If already vice captain, remove vice captaincy
         if (this.viceCaptain === playerId) {
             this.viceCaptain = null;
@@ -217,6 +255,10 @@ class FPLTeamManager {
     }
     
     toggleHave(playerId) {
+        if (this._isReadOnlyCurrentWeek()) {
+            alert('This week is read-only. Create a new week to change team membership.');
+            return;
+        }
         const player = this.players.find(p => p.id === playerId);
         if (!player) return;
         
@@ -257,13 +299,24 @@ class FPLTeamManager {
     
     updateDisplay() {
         const filteredPlayers = this.getFilteredPlayers();
-        
+
         // Update summary
         this.updateSummary();
-        
+
         // Update captaincy info
         this.updateCaptaincyInfo();
-        
+
+        // Update week indicator and controls
+        const isReadOnly = this._isReadOnlyCurrentWeek();
+        if (this.weekLabel) this.weekLabel.textContent = `Week ${this.currentWeek}`;
+        if (this.weekReadonlyBadge) this.weekReadonlyBadge.style.display = isReadOnly ? 'inline-block' : 'none';
+        // Disable add button in read-only weeks
+        if (this.addPlayerBtn) this.addPlayerBtn.disabled = !!isReadOnly;
+        // Prev/Next enablement
+        const totalWeeks = this.getWeekCount();
+        if (this.prevWeekBtn) this.prevWeekBtn.disabled = this.currentWeek <= 1;
+        if (this.nextWeekBtn) this.nextWeekBtn.disabled = this.currentWeek >= totalWeeks;
+
         // Show/hide empty state
         if (this.players.length === 0) {
             this.emptyState.style.display = 'block';
@@ -291,6 +344,7 @@ class FPLTeamManager {
         
         const isCaptain = this.captain === player.id;
         const isViceCaptain = this.viceCaptain === player.id;
+        const isReadOnly = this._isReadOnlyCurrentWeek();
         
         row.innerHTML = `
             <td><strong>${player.name}</strong></td>
@@ -301,21 +355,23 @@ class FPLTeamManager {
             <td style="text-align: center;" data-testid="have-cell-${player.id}">
                 ${player.have ? 
                   `<span class="have-indicator" 
-                        onclick="fplManager.toggleHave('${player.id}')" 
-                        style="cursor: pointer;" 
-                        title="Click to remove from team"
+                        ${isReadOnly ? '' : `onclick="fplManager.toggleHave('${player.id}')"`} 
+                        style="${isReadOnly ? '' : 'cursor: pointer;'}" 
+                        title="${isReadOnly ? 'Read-only week' : 'Click to remove from team'}"
                         data-testid="remove-from-team-${player.id}">✓</span>` : 
                   `<button class="btn btn-secondary" 
-                          onclick="fplManager.toggleHave('${player.id}')" 
+                          ${isReadOnly ? 'disabled' : ''}
+                          ${isReadOnly ? '' : `onclick="fplManager.toggleHave('${player.id}')"`} 
                           style="font-size: 10px; padding: 2px 6px;" 
-                          title="Add to team"
+                          title="${isReadOnly ? 'Read-only week' : 'Add to team'}"
                           data-testid="add-to-team-${player.id}">+</button>`}
             </td>
             <td data-testid="captain-cell-${player.id}">
                 ${isCaptain ? 
                   `<span class="captain-badge" data-testid="captain-badge-${player.id}">C</span>` : 
                   `<button class="btn btn-secondary" 
-                          onclick="fplManager.setCaptain('${player.id}')" 
+                          ${isReadOnly ? 'disabled' : ''}
+                          ${isReadOnly ? '' : `onclick=\"fplManager.setCaptain('${player.id}')\"`} 
                           style="font-size: 10px; padding: 2px 6px;"
                           data-testid="make-captain-${player.id}">C</button>`}
             </td>
@@ -323,7 +379,8 @@ class FPLTeamManager {
                 ${isViceCaptain ? 
                   `<span class="vice-captain-badge" data-testid="vice-captain-badge-${player.id}">VC</span>` : 
                   `<button class="btn btn-secondary" 
-                          onclick="fplManager.setViceCaptain('${player.id}')" 
+                          ${isReadOnly ? 'disabled' : ''}
+                          ${isReadOnly ? '' : `onclick=\"fplManager.setViceCaptain('${player.id}')\"`} 
                           style="font-size: 10px; padding: 2px 6px;"
                           data-testid="make-vice-captain-${player.id}">VC</button>`}
             </td>
@@ -336,14 +393,16 @@ class FPLTeamManager {
             </td>
             <td data-testid="actions-cell-${player.id}">
                 <button class="btn btn-edit" 
-                        onclick="fplManager.openModal('${player.id}')"
+                        ${isReadOnly ? 'disabled' : ''}
+                        ${isReadOnly ? '' : `onclick=\"fplManager.openModal('${player.id}')\"`}
                         data-testid="edit-player-${player.id}">Edit</button>
                 <button class="btn btn-danger" 
-                        onclick="fplManager.deletePlayer('${player.id}')"
+                        ${isReadOnly ? 'disabled' : ''}
+                        ${isReadOnly ? '' : `onclick=\"fplManager.deletePlayer('${player.id}')\"`}
                         data-testid="delete-player-${player.id}">Delete</button>
             </td>
         `;
-        
+
         return row;
     }
     
@@ -386,12 +445,53 @@ class FPLTeamManager {
     }
     
     saveToStorage() {
-        const data = {
-            players: this.players,
-            captain: this.captain,
-            viceCaptain: this.viceCaptain
-        };
-        localStorage.setItem('fpl-team-data', JSON.stringify(data));
+        // Phase 1: Save using weekly schema while remaining backward compatible
+        const existingRaw = localStorage.getItem('fpl-team-data');
+        let root = null;
+        if (existingRaw) {
+            try {
+                root = JSON.parse(existingRaw);
+            } catch (e) {
+                root = null;
+            }
+        }
+
+        // Determine schema
+        if (root && root.weeks) {
+            const currentWeek = this.currentWeek || root.currentWeek || 1;
+            // Update only current week data
+            root.weeks[currentWeek] = root.weeks[currentWeek] || {};
+            root.weeks[currentWeek].players = this.players;
+            root.weeks[currentWeek].captain = this.captain;
+            root.weeks[currentWeek].viceCaptain = this.viceCaptain;
+
+            // Update team snapshot and stats for the week
+            const teamMembers = this.players.filter(p => p.have).map(p => ({
+                playerId: p.id,
+                name: p.name,
+                position: p.position,
+                team: p.team,
+                price: p.price,
+            }));
+            root.weeks[currentWeek].teamMembers = teamMembers;
+            root.weeks[currentWeek].teamStats = {
+                totalValue: teamMembers.reduce((s, p) => s + (Number(p.price) || 0), 0),
+                playerCount: teamMembers.length,
+                updatedDate: new Date().toISOString()
+            };
+
+            root.version = root.version || '2.0';
+            root.currentWeek = currentWeek;
+            localStorage.setItem('fpl-team-data', JSON.stringify(root));
+        } else {
+            // Old schema fallback (kept for backward compatibility)
+            const data = {
+                players: this.players,
+                captain: this.captain,
+                viceCaptain: this.viceCaptain
+            };
+            localStorage.setItem('fpl-team-data', JSON.stringify(data));
+        }
     }
     
     addNotesClickHandlers() {
@@ -426,9 +526,19 @@ class FPLTeamManager {
         if (savedData) {
             try {
                 const data = JSON.parse(savedData);
-                this.players = data.players || [];
-                this.captain = data.captain || null;
-                this.viceCaptain = data.viceCaptain || null;
+                if (data && data.weeks) {
+                    const currentWeek = data.currentWeek || 1;
+                    this.currentWeek = currentWeek;
+                    const week = data.weeks[currentWeek] || {};
+                    this.players = week.players || [];
+                    this.captain = week.captain || null;
+                    this.viceCaptain = week.viceCaptain || null;
+                } else {
+                    // Old schema
+                    this.players = data.players || [];
+                    this.captain = data.captain || null;
+                    this.viceCaptain = data.viceCaptain || null;
+                }
             } catch (error) {
                 console.error('Error loading data from storage:', error);
                 this.players = [];
@@ -442,19 +552,21 @@ class FPLTeamManager {
 // Initialize the app when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
     window.fplManager = new FPLTeamManager();
+    // Expose week navigation helpers for Phase 2 (UI will come in Phase 3)
+    window.fplManagerCreateNewWeek = () => window.fplManager.createNewWeek();
+    window.fplManagerGoToWeek = (n) => window.fplManager.goToWeek(n);
+    window.fplManagerNextWeek = () => window.fplManager.nextWeek();
+    window.fplManagerPrevWeek = () => window.fplManager.prevWeek();
 });
 
 // Load CSV data as initial players
 document.addEventListener('DOMContentLoaded', () => {
-    // Clear any existing data and load CSV data
+    // Seed CSV data ONLY if there is no existing data
     setTimeout(() => {
         if (window.fplManager) {
-            // Clear existing data
-            localStorage.removeItem('fpl-team-data');
-            window.fplManager.players = [];
-            window.fplManager.captain = null;
-            window.fplManager.viceCaptain = null;
-            
+            const existing = localStorage.getItem('fpl-team-data');
+            if (existing) return; // Do not overwrite user data
+
             // CSV data parsed from 2025-Table 1.csv
             const csvPlayers = [
                 {name: 'Areola', position: 'goalkeeper', team: 'WHU', price: 4.5, have: true, notes: ''},
@@ -537,29 +649,273 @@ document.addEventListener('DOMContentLoaded', () => {
                 {name: 'Ekitike', position: 'forward', team: 'LIV', price: 8.5, have: false, notes: ''},
                 {name: 'Gyokeres', position: 'forward', team: 'ARS', price: 9, have: false, notes: 'Gyokeres is the one to monitor most as he could be on penalties for the Gunners.'}
             ];
-            
-            // Set captain based on CSV data
+
+            // Build week 1 with CSV players
+            const players = [];
             let captainPlayerId = null;
-            
             csvPlayers.forEach((playerData, index) => {
-                const player = {
-                    id: `csv_${Date.now()}_${index}`,
-                    ...playerData
-                };
-                
-                // Check if this player is the captain (Salah's in the CSV)
-                if (playerData.name === 'Salah\'s') {
-                    captainPlayerId = player.id;
-                }
-                
-                window.fplManager.players.push(player);
+                const player = { id: `csv_${Date.now()}_${index}`, ...playerData };
+                if (playerData.name === 'Salah\'s') captainPlayerId = player.id;
+                players.push(player);
             });
-            
-            // Set captain
-            window.fplManager.captain = captainPlayerId;
-            
-            window.fplManager.saveToStorage();
+
+            const teamMembers = players.filter(p => p.have).map(p => ({
+                playerId: p.id,
+                name: p.name,
+                position: p.position,
+                team: p.team,
+                price: p.price,
+            }));
+
+            const root = {
+                version: '2.0',
+                currentWeek: 1,
+                weeks: {
+                    1: {
+                        players,
+                        captain: captainPlayerId,
+                        viceCaptain: null,
+                        teamMembers,
+                        teamStats: {
+                            totalValue: teamMembers.reduce((s, p) => s + (Number(p.price) || 0), 0),
+                            playerCount: teamMembers.length,
+                            createdDate: new Date().toISOString()
+                        },
+                        isReadOnly: false
+                    }
+                }
+            };
+
+            localStorage.setItem('fpl-team-data', JSON.stringify(root));
+
+            // Load into manager instance
+            window.fplManager.loadFromStorage();
             window.fplManager.updateDisplay();
         }
     }, 100);
 });
+
+// Phase 1: Migration helper methods
+FPLTeamManager.prototype.migrateStorageIfNeeded = function() {
+    const raw = localStorage.getItem('fpl-team-data');
+    if (!raw) return; // nothing to migrate
+    let data = null;
+    try { data = JSON.parse(raw); } catch (e) { return; }
+
+    // If already in new schema, ensure version and exit
+    if (data && data.weeks) {
+        if (!data.version) {
+            data.version = '2.0';
+            localStorage.setItem('fpl-team-data', JSON.stringify(data));
+        }
+        return;
+    }
+
+    // Old schema -> migrate to week-based schema
+    const players = Array.isArray(data.players) ? data.players : [];
+    const captain = data.captain || null;
+    const viceCaptain = data.viceCaptain || null;
+
+    const teamMembers = players.filter(p => p.have).map(p => ({
+        playerId: p.id,
+        name: p.name,
+        position: p.position,
+        team: p.team,
+        price: p.price,
+    }));
+
+    const migrated = {
+        version: '2.0',
+        currentWeek: 1,
+        weeks: {
+            1: {
+                players,
+                captain,
+                viceCaptain,
+                teamMembers,
+                teamStats: {
+                    totalValue: teamMembers.reduce((s, p) => s + (Number(p.price) || 0), 0),
+                    playerCount: teamMembers.length,
+                    createdDate: new Date().toISOString()
+                },
+                isReadOnly: false
+            }
+        }
+    };
+
+    localStorage.setItem('fpl-team-data', JSON.stringify(migrated));
+};
+
+// Phase 2: Week management helpers
+FPLTeamManager.prototype._getRootData = function() {
+    const defaultWeek = () => ({
+        players: [],
+        captain: null,
+        viceCaptain: null,
+        teamMembers: [],
+        teamStats: { totalValue: 0, playerCount: 0, createdDate: new Date().toISOString() },
+        isReadOnly: false
+    });
+    const defaultRoot = () => ({ version: '2.0', currentWeek: 1, weeks: { 1: defaultWeek() } });
+
+    const raw = localStorage.getItem('fpl-team-data');
+    if (!raw) {
+        const root = defaultRoot();
+        localStorage.setItem('fpl-team-data', JSON.stringify(root));
+        return root;
+    }
+    let data = null;
+    try { data = JSON.parse(raw); } catch (e) { data = null; }
+
+    if (!data || typeof data !== 'object') {
+        const root = defaultRoot();
+        localStorage.setItem('fpl-team-data', JSON.stringify(root));
+        return root;
+    }
+
+    // If already weekly schema and valid, ensure version and return
+    if (data.weeks && typeof data.weeks === 'object') {
+        data.version = data.version || '2.0';
+        // Ensure currentWeek and a valid week exist
+        const cw = Number(data.currentWeek || 1);
+        data.currentWeek = cw >= 1 ? cw : 1;
+        if (!data.weeks[data.currentWeek]) {
+            data.weeks[data.currentWeek] = defaultWeek();
+        }
+        localStorage.setItem('fpl-team-data', JSON.stringify(data));
+        return data;
+    }
+
+    // Old schema -> migrate to weekly on the fly
+    const players = Array.isArray(data.players) ? data.players : [];
+    const captain = data.captain || null;
+    const viceCaptain = data.viceCaptain || null;
+    const teamMembers = players.filter(p => p.have).map(p => ({
+        playerId: p.id,
+        name: p.name,
+        position: p.position,
+        team: p.team,
+        price: p.price,
+    }));
+    const migrated = {
+        version: '2.0',
+        currentWeek: 1,
+        weeks: {
+            1: {
+                players,
+                captain,
+                viceCaptain,
+                teamMembers,
+                teamStats: {
+                    totalValue: teamMembers.reduce((s, p) => s + (Number(p.price) || 0), 0),
+                    playerCount: teamMembers.length,
+                    createdDate: new Date().toISOString()
+                },
+                isReadOnly: false
+            }
+        }
+    };
+    localStorage.setItem('fpl-team-data', JSON.stringify(migrated));
+    return migrated;
+};
+
+FPLTeamManager.prototype._saveRootData = function(root) {
+    root.version = root.version || '2.0';
+    localStorage.setItem('fpl-team-data', JSON.stringify(root));
+};
+
+FPLTeamManager.prototype._computeTeamSnapshot = function(players) {
+    const teamMembers = (players || []).filter(p => p.have).map(p => ({
+        playerId: p.id,
+        name: p.name,
+        position: p.position,
+        team: p.team,
+        price: p.price,
+    }));
+    return {
+        teamMembers,
+        teamStats: {
+            totalValue: teamMembers.reduce((s, p) => s + (Number(p.price) || 0), 0),
+            playerCount: teamMembers.length,
+            updatedDate: new Date().toISOString()
+        }
+    };
+};
+
+FPLTeamManager.prototype.createNewWeek = function() {
+    const root = this._getRootData();
+    const currentWeek = this.currentWeek || root.currentWeek || 1;
+    const source = root.weeks[currentWeek] || { players: [], captain: null, viceCaptain: null };
+
+    // Mark all existing weeks read-only
+    Object.keys(root.weeks).forEach(w => { if (root.weeks[w]) root.weeks[w].isReadOnly = true; });
+
+    const newWeekNumber = Math.max(...Object.keys(root.weeks).map(n => Number(n))) + 1;
+    const clonedPlayers = (source.players || []).map(p => ({ ...p }));
+    const { teamMembers, teamStats } = this._computeTeamSnapshot(clonedPlayers);
+
+    root.weeks[newWeekNumber] = {
+        players: clonedPlayers,
+        captain: source.captain || null,
+        viceCaptain: source.viceCaptain || null,
+        teamMembers,
+        teamStats,
+        isReadOnly: false
+    };
+
+    root.currentWeek = newWeekNumber;
+    this.currentWeek = newWeekNumber;
+
+    // Load into memory
+    this.players = clonedPlayers;
+    this.captain = source.captain || null;
+    this.viceCaptain = source.viceCaptain || null;
+
+    this._saveRootData(root);
+    this.updateDisplay();
+};
+
+FPLTeamManager.prototype.goToWeek = function(weekNumber) {
+    const root = this._getRootData();
+    const week = root.weeks[weekNumber];
+    if (!week) return;
+    this.currentWeek = Number(weekNumber);
+    root.currentWeek = this.currentWeek;
+    this.players = week.players || [];
+    this.captain = week.captain || null;
+    this.viceCaptain = week.viceCaptain || null;
+    this._saveRootData(root);
+    this.updateDisplay();
+};
+
+FPLTeamManager.prototype.nextWeek = function() {
+    const root = this._getRootData();
+    const maxWeek = Math.max(...Object.keys(root.weeks).map(n => Number(n)));
+    const target = Math.min(this.currentWeek + 1, maxWeek);
+    this.goToWeek(target);
+};
+
+FPLTeamManager.prototype.prevWeek = function() {
+    const target = Math.max(1, this.currentWeek - 1);
+    this.goToWeek(target);
+};
+
+FPLTeamManager.prototype.getWeekCount = function() {
+    const root = this._getRootData();
+    if (!root || !root.weeks || typeof root.weeks !== 'object') return 1;
+    return Object.keys(root.weeks).length || 1;
+};
+
+FPLTeamManager.prototype.getCurrentWeekNumber = function() {
+    return this.currentWeek || 1;
+};
+
+// Phase 3: read-only helper
+FPLTeamManager.prototype._isReadOnlyCurrentWeek = function() {
+    const root = this._getRootData();
+    if (!root || !root.weeks || typeof root.weeks !== 'object') return false;
+    const currentWeek = this.currentWeek || root.currentWeek || 1;
+    const week = root.weeks[currentWeek];
+    if (!week) return false;
+    return week.isReadOnly === true;
+};

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,31 @@
     box-sizing: border-box;
 }
 
+/* Week controls */
+.week-controls {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-top: 10px;
+}
+
+.week-indicator {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-weight: 700;
+    color: #2d3748;
+}
+
+.readonly-badge {
+    background: #fde68a;
+    color: #7c2d12;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-size: 12px;
+    border: 1px solid #f59e0b;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     background: linear-gradient(135deg, #1e5631, #2b7d40);
@@ -108,6 +133,12 @@ header h1 {
     cursor: pointer;
     transition: all 0.2s ease;
     font-size: 14px;
+}
+
+.btn:disabled,
+.btn[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 .btn-primary {

--- a/test-utils.js
+++ b/test-utils.js
@@ -53,11 +53,20 @@ const createDOM = () => {
         };
       })();
 
-      // Assign mocks to global
+      // Stub browser dialogs on this jsdom window to prevent noisy "Not implemented: window.alert" logs
+      // Tests may trigger read-only guards and delete confirmations.
+      // We stub per-window because each createDOM() creates a fresh jsdom instance.
+      dom.window.alert = jest.fn();
+      dom.window.confirm = jest.fn(() => true);
+
+      // Assign window, document, and storage mocks to globals so app code under test uses them
       global.window = dom.window;
       global.document = dom.window.document;
       global.localStorage = localStorageMock;
       global.Node = dom.window.Node;
+      // Keep global alert/confirm pointing at the stubbed window versions
+      global.alert = dom.window.alert;
+      global.confirm = dom.window.confirm;
 
       resolve({
         window: dom.window,


### PR DESCRIPTION
### Summary

- Added week feature: create new weeks that copy players, captain/vice, teamMembers, and teamStats; past weeks become read-only; navigate via Prev/Next.
- Introduced public read-only helpers in script.js (getWeekSnapshot, getPlayerSnapshot, isWeekReadOnly, etc.) to stabilize test API.
- Refactored tests to use helpers instead of _getRootData()
.
### Why

- Decouples tests from storage internals and prepares for storage migration.
- Preserves historical team state across weeks.

### Testing

- npm test: 4/4 suites, 25/25 tests passing.

### Files

- script.js: new helper methods; _isReadOnlyCurrentWeek() comment clarification.
- tests/readonlyMode.test.js, tests/weekNavigation.test.js: refactored to helper-based assertions.